### PR TITLE
Closes #3

### DIFF
--- a/neurokin/experiments/neural_correlates.py
+++ b/neurokin/experiments/neural_correlates.py
@@ -489,7 +489,7 @@ def get_neural_correlates_dict(neural_path,
             raw, fs = get_neural_ch(neural_path, channel_of_interest, name)
             is_valid_name = True
             break
-        except:
+        except (AttributeError, TypeError):
             pass
     if not is_valid_name:
         raise Exception("All stream names were invalid")

--- a/neurokin/utils/neural/importing.py
+++ b/neurokin/utils/neural/importing.py
@@ -57,9 +57,8 @@ def import_tdt_channel_data(folderpath, ch=0, t1=0, t2=-1, stream_name="Wav1", s
         raw = stored.data
         fs = stored.fs
 
-    except AttributeError:
-        print(f"No stream named  {stream_name}, please specify the correct stream_name \n "
-              f"Please chose from: {data.streams.__dict__.keys()}")
+    except AttributeError(f"No stream named  {stream_name}, please specify the correct stream_name \n "
+                          f"Please chose from: {data.streams.__dict__.keys()}"):
         return
 
     s1 = 0
@@ -83,7 +82,7 @@ def import_tdt_channel_data(folderpath, ch=0, t1=0, t2=-1, stream_name="Wav1", s
             return
         stim_data = stim_data[..., s1:s2]
 
-    if fs_sync is None:
+    if fs_sync is not None:
         if fs_sync != fs:
             print("Warning: sync frequency is different from the data frequency")
 


### PR DESCRIPTION
Suppresses Attribute and Type error during the loading of tdt files, when iterating through multiple possible stream names. It still raises the error if all streams name are invalid.